### PR TITLE
actually overwrite Exporter.__init__

### DIFF
--- a/ankiExporting.py
+++ b/ankiExporting.py
@@ -31,6 +31,7 @@ oldInit = Exporter.__init__
 def __init__(self,*args, **kwargs):
     oldInit(self, *args, **kwargs)
     self.cids = None
+Exporter.__init__ = __init__
 
 def needSiblings(self):
     userOption = mw.addonManager.getConfig(__name__)


### PR DESCRIPTION
I made a custom exporting add-on tonight. When I put it into my main addon folder that contains your "anki-export-from-browser" I got this error

```python
  .....
    exporter.exportInto(file)
  File "/usr/share/anki/anki/exporting.py", line 288, in exportInto
    media = self.doExport(z, path)
  File "/usr/share/anki/anki/exporting.py", line 296, in doExport
    AnkiExporter.exportInto(self, colfile)
  File "/usr/share/anki/anki/exporting.py", line 155, in exportInto
    cids = self.cardIds()
  File "/home/ij/.local/share/Anki2/addons21/1983204951/ankiExporting.py", line 55, in cardIds
    if self.cids is not None:
<class 'AttributeError'>: 'AnkiPackageExporter' object has no attribute 'cids'
```

When I added the line from this commit the error disappears and so far I haven't noted a problem. I made this pull request because it's more clear what I'm referring to and not because I'm convinced that this line must be included ...

As always: Thanks for your great contributions (especially for fixing scheduler related problems on ankidroid ...).